### PR TITLE
response validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "homepage": "https://github.com/salesforce/refocus-collector-eval#readme",
   "dependencies": {
     "accept-parser": "^1.0.1",
+    "ajv": "^6.5.2",
     "errors": "^0.3.0",
     "joi": "^13.0.1",
     "just-template": "^1.1.22",

--- a/test/RefocusCollectorEval.js
+++ b/test/RefocusCollectorEval.js
@@ -428,4 +428,120 @@ describe('test/RefocusCollectorEval.js >', (done) => {
       expect(actual).to.have.property('Authorization', 'bearer: abcdef');
     });
   }); // prepareHeaders
+
+  describe('validateResponseBody >', () => {
+    const schema = JSON.stringify({
+      type: 'object',
+      properties: {
+        body: {
+          type: 'object',
+          required: ['prop1'],
+          properties: {
+            prop1: { type: 'string', },
+            prop2: { type: 'number', },
+          },
+        },
+      },
+    });
+
+    it('valid', () => {
+      const res = {
+        body: {
+          prop1: '...',
+        },
+      };
+      expect(() => rce.validateResponseBody(res, schema)).to.not.throw();
+    });
+
+    it('invalid - wrong type', () => {
+      const res = {
+        body: {
+          prop1: '...',
+          prop2: '...',
+        },
+      };
+      expect(() => rce.validateResponseBody(res, schema)).to.throw(
+        'Response validation failed - /body/prop2 - ' +
+        'should be number'
+      );
+    });
+
+    it('invalid - required prop missing', () => {
+      const res = {
+        body: {
+          prop2: 4,
+        },
+      };
+      expect(() => rce.validateResponseBody(res, schema)).to.throw(
+        'Response validation failed - /body - ' +
+        "should have required property 'prop1'"
+      );
+    });
+
+    it('response empty (ok)', () => {
+      const res = {};
+      expect(() => rce.validateResponseBody(res, schema)).to.not.throw();
+    });
+
+    it('response null (error)', () => {
+      const res = null;
+      expect(() => rce.validateResponseBody(res, schema)).to.throw(
+        'Response validation failed - / - should be object'
+      );
+    });
+
+    it('response not an object (error)', () => {
+      const res = '...';
+      expect(() => rce.validateResponseBody(res, schema)).to.throw(
+        'Response validation failed - res must be an object'
+      );
+    });
+
+    it('schema empty (ok)', () => {
+      const schema = '{}';
+      const res = {
+        body: {
+          prop1: '...',
+        },
+      };
+      expect(() => rce.validateResponseBody(res, schema)).to.not.throw();
+    });
+
+    it('schema not a string (error)', () => {
+      const schema = {};
+      const res = {
+        body: {
+          prop1: '...',
+        },
+      };
+      expect(() => rce.validateResponseBody(res, schema)).to.throw(
+        'Response validation failed - schema must be a string'
+      );
+    });
+
+    it('schema invalid json', () => {
+      const schema = 'aaa';
+      const res = {
+        body: {
+          prop1: '...',
+        },
+      };
+      expect(() => rce.validateResponseBody(res, schema)).to.throw(
+        'Response validation failed - schema must be valid JSON'
+      );
+    });
+
+    it('schema null (error)', () => {
+      const schema = {};
+      const res = {
+        body: {
+          prop1: '...',
+        },
+      };
+      expect(() => rce.validateResponseBody(res, schema)).to.throw(
+        'Response validation failed - schema must be a string'
+      );
+    });
+
+  });
 });


### PR DESCRIPTION
This is one of 3 PRs that for setting up response validation:

https://github.com/salesforce/refocus-sample-generator-template-utils/pull/26
https://github.com/salesforce/refocus-collector/pull/141
https://github.com/salesforce/refocus-collector-eval/pull/15 (this one)

The tests won't pass in sgt-utils and refocus-collector until the eval PR is merged.

Currently this is using JSON Schema because Joi does not support serialization. Now that everything is in place, it should be relatively straightforward to swap out JSON Schema for something else if we can make it work. I have created a separate story to look into other more user-friendly options.