### PR TITLE
expand object fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ const sampleSchema = RefocusCollectorEval.sampleSchema;
 - [Refocus Sample Generator Template Utils](https://github.com/salesforce/refocus-sample-generator-template-utils)
 
 # Version History
+- 1.11.1: Expand object bug fix.
 - 1.11.0: Removed unnecessary logging.
 - 1.10.0: Add new expandObject function to apply variable expansion across multiple attributes of an object instead of just for a single stering.
 - 1.9.0: Add aspects and subjects to context for url variable substitution; support object and array references in template expansion.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/refocus-collector-eval",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Collector eval utils used by Refocus Collector System to validate transform and toUrl functions.",
   "main": "src/RefocusCollectorEval.js",
   "directories": {

--- a/src/RefocusCollectorEval.js
+++ b/src/RefocusCollectorEval.js
@@ -359,7 +359,9 @@ class RefocusCollectorEval {
         if (typeof obj[key] === 'object') {
           doTraverse(obj[key]);
         } else {
-          obj[key] = utils.expand(obj[key], ctx);
+          if (typeof obj[key] === 'string') {
+            obj[key] = utils.expand(obj[key], ctx);
+          }
         }
       }
 

--- a/test/RefocusCollectorEval.js
+++ b/test/RefocusCollectorEval.js
@@ -611,6 +611,8 @@ describe('test/RefocusCollectorEval.js >', (done) => {
       const obj = {
         abc: 'test',
         abc1: 'test1',
+        abc2: true,
+        abc3: 3,
       };
       const ctx = {
         test: 'qwerty',
@@ -619,6 +621,8 @@ describe('test/RefocusCollectorEval.js >', (done) => {
       const expandedObject = {
         abc: 'test',
         abc1: 'test1',
+        abc2: true,
+        abc3: 3,
       };
 
       expect(rce.expandObject(obj, ctx)).to.deep.equal(expandedObject);


### PR DESCRIPTION
expand assumes it will be passed a string, so if expandObject tries to expand a non-string it will overwrite it.

This was exposed by the oauth fix PR - previously this wasn't actually being tested because expandObject was called after token creation.